### PR TITLE
fix: Adding context on ApolloServer

### DIFF
--- a/src/handlers/graphql.js
+++ b/src/handlers/graphql.js
@@ -59,6 +59,7 @@ module.exports =
         schema,
         endpointUrl,
         formatError,
+        context: ({ctx}) => ctx,
         introspection: process.env.NODE_ENV === 'development',
         debug: process.env.NODE_ENV === 'development',
         logger: logger.child({ service: 'graphql', endpointUrl }),


### PR DESCRIPTION
Hi mas Ryan, i have problem when i want to get `context` on GrapQL resolver context parameter, it wont return any object value, i found this [issue](https://github.com/apollographql/apollo-server/issues/1392) related to my problem, then i add `context` option on ApolloServer options Configuration, so the context can pass to GrapQL resolver.

Thank you mas Ryan